### PR TITLE
pyside6: Rebuild to fix imported QtGui symbols

### DIFF
--- a/mingw-w64-pyside6/PKGBUILD
+++ b/mingw-w64-pyside6/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(${MINGW_PACKAGE_PREFIX}-shiboken6
          ${MINGW_PACKAGE_PREFIX}-${_realname}
          ${MINGW_PACKAGE_PREFIX}-${_realname}-tools)
 pkgver=6.8.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Enables the use of Qt6 APIs in Python applications (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')


### PR DESCRIPTION
Fixes #22956